### PR TITLE
Include a readme for the Ruby case

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1,0 +1,8 @@
+Gilded Rose in Ruby
+===================
+
+To run, you will need at least ruby 1.9. Install a recent version using [rvm](https://rvm.io/).
+
+Run the tests suite:
+
+    ruby gilded_rose_test.rb


### PR DESCRIPTION
While setting up my system, I noticed we really need a recent Ruby (which isn't installed by default on Mac). I added a simple readme to the Ruby case for this.
